### PR TITLE
Fixed timeouts on Get-PnPSiteCollectionAdmin

### DIFF
--- a/Commands/Site/GetSiteCollectionAdmin.cs
+++ b/Commands/Site/GetSiteCollectionAdmin.cs
@@ -42,10 +42,10 @@ namespace SharePointPnP.PowerShell.Commands.Site
                     g => g.LoginName)
            };
 
-            ClientContext.Load(SelectedWeb.SiteUsers, users => users.Include(retrievalExpressions));
+            var siteCollectionAdminUsersQuery = SelectedWeb.SiteUsers.Where(u => u.IsSiteAdmin);
+            var siteCollectionAdminUsers = ClientContext.LoadQuery(siteCollectionAdminUsersQuery.Include(retrievalExpressions));
             ClientContext.ExecuteQueryRetry();
 
-            var siteCollectionAdminUsers = SelectedWeb.SiteUsers.Where(su => su.IsSiteAdmin);
             WriteObject(siteCollectionAdminUsers, true);
         }
     }


### PR DESCRIPTION
## Type ##
- [x] Bug Fix
- [ ] New Feature
- [ ] Sample

## Related Issues? ##
N/A

## What is in this Pull Request ? ##
Fixed timeouts when using `Get-PnPSiteCollectionAdmin` on site collections with many users. The old logic loaded all users of the site and filtered afterwards. The new logic includes the filter in the query itself.

The same problem will occur when using `GetAdministrators` from [SecurityExtensions](https://github.com/pnp/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Extensions/SecurityExtensions.cs) in PnP-Sites-Core. This will need an additional fix.
